### PR TITLE
added PctString::into_string(), fixed test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,12 @@ impl PctString {
 	pub fn as_pct_str(&self) -> &PctStr {
 		unsafe { PctStr::new_unchecked(&self.data) }
 	}
+
+	/// Return the internal string of the [`PctString`], consuming it
+	#[inline]
+	pub fn into_string(self) -> String {
+		self.data
+	}
 }
 
 impl std::ops::Deref for PctString {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,9 +488,9 @@ impl PartialEq<PctStr> for PctString {
 	}
 }
 
-impl PartialEq<str> for PctString {
+impl PartialEq<&str> for PctString {
 	#[inline]
-	fn eq(&self, other: &str) -> bool {
+	fn eq(&self, other: &&str) -> bool {
 		let mut a = self.chars();
 		let mut b = other.chars();
 
@@ -505,6 +505,13 @@ impl PartialEq<str> for PctString {
 		}
 
 		true
+	}
+}
+
+impl PartialEq<str> for PctString {
+	#[inline]
+	fn eq(&self, other: &str) -> bool {
+		self.eq(&other)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use pct_str::PctStr;
 //!
-//! let pct_str = PctStr::new("Hello%20World%21")?;
+//! let pct_str = PctStr::new("Hello%20World%21").unwrap();
 //!
 //! assert!(pct_str == "Hello World!");
 //!
@@ -22,10 +22,10 @@
 //! To create new percent-encoded strings, use the [`PctString`] to copy or encode new strings.
 //!
 //! ```
-//! use pct_str::PctString;
+//! use pct_str::{PctString, URIReserved};
 //!
 //! // Copy the given percent-encoded string.
-//! let pct_string = PctString::new("Hello%20World%21")?;
+//! let pct_string = PctString::new("Hello%20World%21").unwrap();
 //!
 //! // Encode the given regular string.
 //! let pct_string = PctString::encode("Hello World!".chars(), URIReserved);
@@ -37,6 +37,8 @@
 //! by implementing the [`Encoder`] trait.
 //!
 //! ```
+//! use pct_str::{URIReserved, PctString};
+//!
 //! struct CustomEncoder;
 //!
 //! impl pct_str::Encoder for CustomEncoder {
@@ -124,8 +126,10 @@ impl<'a> std::iter::FusedIterator for Chars<'a> { }
 /// # Examples
 ///
 /// ```
+/// use pct_str::PctStr;
+///
 /// let buffer = "Hello%20World%21";
-/// let pct_str = PctStr::new(buffer)?;
+/// let pct_str = PctStr::new(buffer).unwrap();
 ///
 /// // You can compare percent-encoded strings with a regular string.
 /// assert!(pct_str == "Hello World!");
@@ -333,6 +337,8 @@ impl fmt::Debug for PctStr {
 /// # Example
 ///
 /// ```
+/// use pct_str::{PctString, URIReserved};
+///
 /// let pct_string = PctString::encode("Hello World!".chars(), URIReserved);
 /// println!("{}", pct_string.as_str()); // => Hello World%21
 /// ```
@@ -340,6 +346,8 @@ impl fmt::Debug for PctStr {
 /// Custom encoder implementation:
 ///
 /// ```
+/// use pct_str::{PctString, URIReserved};
+///
 /// struct CustomEncoder;
 ///
 /// impl pct_str::Encoder for CustomEncoder {
@@ -399,6 +407,8 @@ impl PctString {
 	/// # Example
 	///
 	/// ```
+	/// use pct_str::{PctString, URIReserved};
+	///
 	/// let pct_string = PctString::encode("Hello World!".chars(), URIReserved);
 	/// println!("{}", pct_string.as_str()); // => Hello World%21
 	/// ```


### PR DESCRIPTION
I added the ``PctString::into_string()`` that return the inner ``String`` of a ``PctString`` (rather than using ``pct_string.to_str().to_string()``. This allow to have shorter code in dependant code, and remove a useless copy.

I also fixed various bug, most notably I added a ``PartialEq<&str> for PctString`` to compare ``PctString`` with string (as in example file ``str.rs``).

I also added ``use`` and ``.unwrap()`` in documentation example, so now all test work when tested with ``cargo test``.

Also, it would be nice to make a new release with those addition.